### PR TITLE
Fix breaking Setting object after loading this plugin.

### DIFF
--- a/lib/patches/model/setting_patch.rb
+++ b/lib/patches/model/setting_patch.rb
@@ -10,5 +10,7 @@ module Pwfmt::SettingPatch
   end
 end
 
-require 'setting'
-Setting.__send__(:include, Pwfmt::SettingPatch)
+Rails.configuration.to_prepare do
+  require 'setting'
+  Setting.__send__(:include, Pwfmt::SettingPatch)
+end


### PR DESCRIPTION
Without this patch, this plugin requires 'setting' at plugin loading,
and after that, next loaded plugin cannot access to
Setting.plugin_#{@plugin.id} method (NoMethodError).

This seems to be related to the thread below:
  http://www.redmine.org/boards/3/topics/16587

## Japanese

Ruby 素人なのでこの修正が適切なのかどうかわからないのですが、手元の

- Ruby 2.0.0-p598
- Rails 3.2.9
- Redmine 2.5.3
- redmine_slack と併用

という環境でうまく動かなかったので追ってみました。

どうも上記 URL に書いてある事象と同じような状況だったので、見よう見まねで入れてみたところ、動くようになりました。

テストの動かし方がわかっていないのでテストかけていませんが、もし問題なさそうなら pull していただければと思います。