### PR TITLE
Avoid overwriting all wiki assets

### DIFF
--- a/lib/patches/helper/markdown_helper_patch.rb
+++ b/lib/patches/helper/markdown_helper_patch.rb
@@ -6,15 +6,13 @@ module Pwfmt::MarkdownHelperPatch
   end
 
   def heads_for_wiki_formatter
-    unless @heads_for_wiki_formatter_included
+    super
+
+    unless @pwfmt_heads_for_wiki_formatter_included
       content_for :header_tags do
-        javascript_include_tag('jstoolbar/jstoolbar') +
-        javascript_include_tag('toolbar', plugin: 'redmine_persist_wfmt') +
-        javascript_include_tag("jstoolbar/lang/jstoolbar-#{current_language.to_s.downcase}") +
-        javascript_tag("var wikiImageMimeTypes = #{Redmine::MimeType.by_type('image').to_json};") +
-        stylesheet_link_tag('jstoolbar')
+        javascript_include_tag('toolbar', plugin: 'redmine_persist_wfmt')
       end
-      @heads_for_wiki_formatter_included = true
+      @pwfmt_heads_for_wiki_formatter_included = true
     end
   end
 end

--- a/lib/patches/helper/textile_helper_patch.rb
+++ b/lib/patches/helper/textile_helper_patch.rb
@@ -7,15 +7,13 @@ module Pwfmt::TextileHelperPatch
 
   def heads_for_wiki_formatter
     Rails.logger.debug("pwfmt: #{@heads_for_wiki_formatter_included}")
-    unless @heads_for_wiki_formatter_included
+    super
+
+    unless @pwfmt_heads_for_wiki_formatter_included
       content_for :header_tags do
-        javascript_include_tag('jstoolbar/jstoolbar') +
-        javascript_include_tag('toolbar', plugin: 'redmine_persist_wfmt') +
-        javascript_include_tag("jstoolbar/lang/jstoolbar-#{current_language.to_s.downcase}") +
-        javascript_tag("var wikiImageMimeTypes = #{Redmine::MimeType.by_type('image').to_json};") +
-        stylesheet_link_tag('jstoolbar')
+        javascript_include_tag('toolbar', plugin: 'redmine_persist_wfmt')
       end
-      @heads_for_wiki_formatter_included = true
+      @pwfmt_heads_for_wiki_formatter_included = true
     end
   end
 end


### PR DESCRIPTION
Currently redmine_persist_wfmt overrides `heads_for_wiki_formatter` and does not invoke the original one. This implementation conflicts some plugins which override the same method. (e.g. https://github.com/wate/graphviz/)

This patch solves this conflict by making redmine_persist_wfmt invoke the original `heads_for_wiki_formatter`.

By this change, jstoolbar/textile.js or jstoolbar/markdown.js from Redmine is loaded by the original method, but buttons defined by these files are immediately overwritten by toolbar.js from redmine_persist_wfmt.

ref. https://www.redmine.org/issues/31302