### PR TITLE
Add common mark for redmine 5.0 or later.

### DIFF
--- a/assets/javascripts/pwfmt.js
+++ b/assets/javascripts/pwfmt.js
@@ -47,7 +47,8 @@ if (window.pwfmt == null) {
     },
     isMarkdownSelected: function(toolbar) {
       var idx = toolbar.formatSelector.selectedIndex;
-      return toolbar.formatSelector.options[idx].value === 'markdown';
+      const markdownFormats = ['markdown', 'common_mark']
+      return markdownFormats.includes(toolbar.formatSelector.options[idx].value);
     }
   };
 }

--- a/lib/pwfmt/patches/helper/common_mark_helper_patch.rb
+++ b/lib/pwfmt/patches/helper/common_mark_helper_patch.rb
@@ -1,0 +1,29 @@
+module Pwfmt
+  module Patches
+    module Helper
+      # This patch extends common_mark helper
+      module CommonMarkHelperPatch
+        include Pwfmt::Helper
+
+        # append dropdown for selecting format.
+        def wikitoolbar_for(field_id, preview_url = preview_text_path)
+          super(field_id, preview_url) + javascript_tag(pwfmt_select_script(field_id, 'common_mark'))
+        end
+
+        # overrides toolbar script for switching action by selected format.
+        def heads_for_wiki_formatter
+          super
+
+          return if @pwfmt_heads_for_wiki_formatter_included
+
+          content_for :header_tags do
+            javascript_include_tag('toolbar', plugin: 'redmine_persist_wfmt')
+          end
+          @pwfmt_heads_for_wiki_formatter_included = true
+        end
+      end
+    end
+  end
+end
+
+Redmine::WikiFormatting::CommonMark::Helper.prepend(Pwfmt::Patches::Helper::CommonMarkHelperPatch)


### PR DESCRIPTION
Add common mark helper patch for Redmine 5.0 or later.
CommonMark is available for Redmine 5.0 and later, and has been the default since 5.1.
The format selection list can be displayed correctly even if CommonMark is set in /settings.